### PR TITLE
Fix fog level due to moving helmet visor far away plus tweaks

### DIFF
--- a/Plugin.cs
+++ b/Plugin.cs
@@ -23,6 +23,8 @@ namespace j_red
         [Range(0f, 10f)]
         public ConfigEntry<float> motionSwayIntensity;
 
+        public ConfigEntry<bool> disableHUDHelmetVisor;
+
     }
 
     [BepInPlugin(GUID, ModName, ModVersion)]
@@ -54,6 +56,9 @@ namespace j_red
                 config.lockFOV = Config.Bind("General", "Lock FOV", true, "Determines if the player field of view should remain locked. Disable for mod compatibility.");
                 config.FOV = Config.Bind("General", "Field of View", 66f, "FOV to use when locked. Has no effect if LockFOV is false.");
                 config.terminalFOV = Config.Bind("General", "Terminal Field of View", 66f, "FOV to use in terminal window.");
+
+                // HUD Helmet Visor
+                config.disableHUDHelmetVisor = Config.Bind("General", "Disable HUD helmet visor effect", true, "If enabled, will remove the helmet visor effect from the HUD.");
             }
 
             logger = BepInEx.Logging.Logger.CreateLogSource(GUID);


### PR DESCRIPTION
Changes:

1. Fog level was being messed up due to the helmet visor being moved far behind the player's camera making the map much clearer than intended.  This is fixed by keeping the helmet visor position in sync with the camera and simply disabling its MeshRenderer.
2. In order to keep the helmet visor in sync with the camera, the sway removal logic needed to be done as a prefix patch.  There must be some calculations done within vanilla LateUpdate() that is using the original camera position which became out of sync with the new camera position update done inside the old postfix patch.  This caused the helmet visor to appear to bounce uncontrollably if it was re-enabled.
3. Leaving the camera rotation untouched if player enables head bobbing so that it behaves more like vanilla, especially evident when crouch walking.
4. When head bobbing is disabled, only touch camera position and rotation if player is not in some kind of special animation, such as the spawning/reviving animation.  This caused a problem where the player was no longer looking at their hands when spawning/reviving.
5. While making this change, it was hard to resist adding a config option to disable/enable the helmet visor, which should also resolve issue #9.
6. Removing the call to CacheCameraContainer(ref __instance) in LateUpdatePatch because it doesn't seem to do much for me and removing it would save a bit on processing.  If this breaks anything we can bring it back.

Thanks much!